### PR TITLE
Removed SEDOL Field

### DIFF
--- a/2iqFinInst_not_defined
+++ b/2iqFinInst_not_defined
@@ -30,7 +30,6 @@ st.share_range, st.no_of_shares, st."comment", twiqac."x2iqAssetClass", twiqac."
 
 
 FROM 
-sbb."SenatorTrades" as st
 
 JOIN 
 sbb."SenatorFilings" as senf


### PR DESCRIPTION
Was not a requirement from client, so removing this field.